### PR TITLE
Export Ws and Index HTTP handlers

### DIFF
--- a/statsviz.go
+++ b/statsviz.go
@@ -9,36 +9,17 @@ import (
 	"github.com/arl/statsviz/websocket"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
+func init() {
+	http.Handle("/debug/statsviz/", Index)
+	http.HandleFunc("/debug/statsviz/ws", Ws)
 }
 
-type stats struct {
-	Mem          runtime.MemStats
-	NumGoroutine int
-}
-
-const (
-	defaultSendPeriod = time.Second
-)
-
-// sendStats indefinitely send runtime statistics on the websocket connection.
-func sendStats(conn *websocket.Conn) error {
-	tick := time.NewTicker(defaultSendPeriod)
-
-	var stats stats
-	for {
-		select {
-		case <-tick.C:
-			runtime.ReadMemStats(&stats.Mem)
-			stats.NumGoroutine = runtime.NumGoroutine()
-			if err := conn.WriteJSON(stats); err != nil {
-				return err
-			}
-		}
-	}
-}
+// Index responds to a request for /debug/statsviz with the statsviz HTML page
+// which shows a live visualization of the statistics sent by the application
+// over the websocket handler Ws.
+//
+// The package initialization registers it as /debug/statsviz/.
+var Index = http.StripPrefix("/debug/statsviz/", http.FileServer(assets))
 
 // Ws upgrades the HTTP server connection to the WebSocket protocol and sends
 // application statistics every second.
@@ -61,14 +42,31 @@ func Ws(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Index responds to a request for /debug/statsviz with the statsviz HTML page
-// which shows a live visualization of the statistics sent by the application
-// over the websocket handler Ws.
-//
-// The package initialization registers it as /debug/statsviz/.
-var Index = http.StripPrefix("/debug/statsviz/", http.FileServer(assets))
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
 
-func init() {
-	http.Handle("/debug/statsviz/", Index)
-	http.HandleFunc("/debug/statsviz/ws", Ws)
+type stats struct {
+	Mem          runtime.MemStats
+	NumGoroutine int
+}
+
+const defaultSendPeriod = time.Second
+
+// sendStats indefinitely send runtime statistics on the websocket connection.
+func sendStats(conn *websocket.Conn) error {
+	tick := time.NewTicker(defaultSendPeriod)
+
+	var stats stats
+	for {
+		select {
+		case <-tick.C:
+			runtime.ReadMemStats(&stats.Mem)
+			stats.NumGoroutine = runtime.NumGoroutine()
+			if err := conn.WriteJSON(stats); err != nil {
+				return err
+			}
+		}
+	}
 }


### PR DESCRIPTION
Export Ws and Index HTTP handlers
They're needed to whoever would like to expose statsviz handlers to some path that is different to `/debug/statsviz/`