### PR TITLE
New API to register handlers, dont use init anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ The handled path is `/debug/statsviz/`.
 
 Then open your browser at http://localhost:6060/debug/statsviz/
 
+Examples
+--------
+
+Using `http.DefaultServeMux`:
+ - [_example/default.go](./_example/default.go)
+
+Using your own `http.ServeMux`:
+ - [_example/mux.go](./_example/mux.go)
+
+Using [gorilla/mux](https://github.com/gorilla/mux) Router:
+ - [_example/gorilla/mux.go](./_example/gorilla/mux.go)
+
 
 Plots
 -----

--- a/README.md
+++ b/README.md
@@ -6,24 +6,30 @@ Statsviz
 Instant live visualization of your Go application runtime statistics 
 (GC, MemStats, etc.).
 
- - Import `import _ "github.com/arl/statsviz"` (à la `"net/http/pprof"`)
+ - Import `import "github.com/arl/statsviz"`
+ - Register statsviz HTTP handlers
+ - Start your program
  - Open your browser at `http://host:port/debug/statsviz`
  - Enjoy... 
-
-
-Installation
-------------
-
-```bash
-go get -u github.com/arl/statsviz
-```
 
 
 Usage
 -----
 
-This package is typically only imported for the side effect of registering its
-HTTP handler. The handled path is `/debug/statsviz/`.
+    go get -u github.com/arl/statsviz
+
+Either `Register` statsviz HTTP handlers with the [http.ServeMux](https://pkg.go.dev/net/http?tab=doc#ServeMux) you're using (preferred method):
+
+```go
+	mux := http.NewServeMux()
+	statsviz.Register(mux)
+```
+
+Or register them with the `http.DefaultServeMux`:
+
+```go
+	statsviz.RegisterDefault()
+```
 
 If your application is not already running an HTTP server, you need to start
 one. Add `"net/http"` and `"log"` to your imports and the following code to your
@@ -35,8 +41,7 @@ go func() {
 }()
 ```
 
-If you are not using [http.DefaultServeMux](https://pkg.go.dev/net/http?tab=doc#ServeMux),
-you will have to register the handler with the mux you are using.
+The handled path is `/debug/statsviz/`.
 
 Then open your browser at http://localhost:6060/debug/statsviz/
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Then open your browser at http://localhost:6060/debug/statsviz/
 Plots
 -----
 
-On the plots where it matters, garbage collections are shown as vertical bars.
+On the plots where it matters, garbage collections are shown as vertical lines.
+
 ### Heap
 <img alt="Heap plot image" src="https://github.com/arl/statsviz/raw/readme-docs/heap.png" width="600">
 
@@ -69,7 +70,7 @@ Contributing
 ------------
 
 Pull-requests are welcome!
-More details in [Contributing](CONTRIBUTING.md)
+More details in [CONTRIBUTING.md](CONTRIBUTING.md)
 
 
 License

--- a/_example/default.go
+++ b/_example/default.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	_ "github.com/arl/statsviz"
+	"github.com/arl/statsviz"
 )
 
 func garbage() []byte {
@@ -40,5 +40,7 @@ func main() {
 		}
 	}()
 
+	// Register statsviz handlers on the default serve mux.
+	statsviz.RegisterDefault()
 	http.ListenAndServe(":8080", nil)
 }

--- a/_example/default.go
+++ b/_example/default.go
@@ -1,46 +1,35 @@
 package main
 
 import (
-	"fmt"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/arl/statsviz"
 )
 
-func garbage() []byte {
-	var b []byte
-
-	rnd := rand.New(rand.NewSource(0))
-	switch rnd.Intn(4) {
-	case 0:
-		b = make([]byte, 8192+rnd.Intn(8192*4))
-	case 1:
-		b = make([]byte, 2048+rnd.Intn(4096))
-	case 2, 3:
-		b = make([]byte, rnd.Intn(128))
-	}
-
-	return b
-}
-
 func main() {
-	// Force the GC to work
-	go func() {
-		m := make(map[string][]byte)
-		i := 0
-		for {
-			m[fmt.Sprintf("%d", i)] = garbage()
-			time.Sleep(10 * time.Millisecond)
-			i++
-			if i%(10*100) == 0 {
-				m = make(map[string][]byte)
-			}
-		}
-	}()
+	// Force the GC to work to make the plots "move".
+	go work()
 
 	// Register statsviz handlers on the default serve mux.
 	statsviz.RegisterDefault()
 	http.ListenAndServe(":8080", nil)
+}
+
+func work() {
+	// Generate some allocations
+	m := map[string][]byte{}
+
+	for {
+		b := make([]byte, 512+rand.Intn(16*1024))
+		m[strconv.Itoa(len(m)%(10*100))] = b
+
+		if len(m)%(10*100) == 0 {
+			m = make(map[string][]byte)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/_example/gorilla/mux.go
+++ b/_example/gorilla/mux.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/arl/statsviz"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	// Force the GC to work to make the plots "move".
+	go work()
+
+	// Create a Gorilla router and register statsviz handlers.
+	r := mux.NewRouter()
+	r.Methods("GET").Path("/debug/statsviz/ws").Name("GET /debug/statsviz/ws").HandlerFunc(statsviz.Ws)
+	r.Methods("GET").PathPrefix("/debug/statsviz/").Name("GET /debug/statsviz/").Handler(statsviz.Index)
+
+	mux := http.NewServeMux()
+	mux.Handle("/", r)
+	http.ListenAndServe(":8080", mux)
+}
+
+func work() {
+	// Generate some allocations
+	m := map[string][]byte{}
+
+	for {
+		b := make([]byte, 512+rand.Intn(16*1024))
+		m[strconv.Itoa(len(m)%(10*100))] = b
+
+		if len(m)%(10*100) == 0 {
+			m = make(map[string][]byte)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/_example/mux.go
+++ b/_example/mux.go
@@ -40,9 +40,9 @@ func main() {
 		}
 	}()
 
+	// Create a serve mux and register statsviz handlers.
 	mux := http.NewServeMux()
-	mux.Handle("/debug/statsviz/", statsviz.Index)
-	mux.HandleFunc("/debug/statsviz/ws", statsviz.Ws)
+	statsviz.Register(mux)
 
-	http.ListenAndServe(":8080", nil)
+	http.ListenAndServe(":8080", mux)
 }

--- a/_example/mux.go
+++ b/_example/mux.go
@@ -1,48 +1,37 @@
 package main
 
 import (
-	"fmt"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/arl/statsviz"
 )
 
-func garbage() []byte {
-	var b []byte
-
-	rnd := rand.New(rand.NewSource(0))
-	switch rnd.Intn(4) {
-	case 0:
-		b = make([]byte, 8192+rnd.Intn(8192*4))
-	case 1:
-		b = make([]byte, 2048+rnd.Intn(4096))
-	case 2, 3:
-		b = make([]byte, rnd.Intn(128))
-	}
-
-	return b
-}
-
 func main() {
-	// Force the GC to work
-	go func() {
-		m := make(map[string][]byte)
-		i := 0
-		for {
-			m[fmt.Sprintf("%d", i)] = garbage()
-			time.Sleep(10 * time.Millisecond)
-			i++
-			if i%(10*100) == 0 {
-				m = make(map[string][]byte)
-			}
-		}
-	}()
+	// Force the GC to work to make the plots "move".
+	go work()
 
 	// Create a serve mux and register statsviz handlers.
 	mux := http.NewServeMux()
 	statsviz.Register(mux)
 
 	http.ListenAndServe(":8080", mux)
+}
+
+func work() {
+	// Generate some allocations
+	m := map[string][]byte{}
+
+	for {
+		b := make([]byte, 512+rand.Intn(16*1024))
+		m[strconv.Itoa(len(m)%(10*100))] = b
+
+		if len(m)%(10*100) == 0 {
+			m = make(map[string][]byte)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
 }

--- a/statsviz.go
+++ b/statsviz.go
@@ -31,9 +31,18 @@ import (
 	"github.com/arl/statsviz/websocket"
 )
 
-func init() {
-	http.Handle("/debug/statsviz/", Index)
-	http.HandleFunc("/debug/statsviz/ws", Ws)
+// Register registers statsviz HTTP handlers on the provided mux.
+func Register(mux *http.ServeMux) {
+	mux.Handle("/debug/statsviz/", Index)
+	mux.HandleFunc("/debug/statsviz/ws", Ws)
+}
+
+// RegisterDefault registers statsviz HTTP handlers on the default serve mux.
+//
+// Note this is not advised on a production server, unless it only serves on
+// localhost.
+func RegisterDefault() {
+	Register(http.DefaultServeMux)
 }
 
 // Index responds to a request for /debug/statsviz with the statsviz HTML page


### PR DESCRIPTION
 - define `Register(*http.ServeMux)` and `RegisterDefault()` so that we don't force the default serve mux on library users (previously registered in `init()`).

 - modify examples to adapt to the new API

 - add `_example/gorilla/mux.go` to show how to register statsviz handlers with a gorilla mux router

 - update README to refect the new API