### PR TITLE
Do not log errors

### DIFF
--- a/statsviz.go
+++ b/statsviz.go
@@ -23,7 +23,6 @@
 package statsviz
 
 import (
-	"log"
 	"net/http"
 	"runtime"
 	"time"
@@ -62,15 +61,13 @@ func Ws(w http.ResponseWriter, r *http.Request) {
 
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Println("can't upgrade HTTP connection to Websocket protocol:", err)
 		return
 	}
 	defer ws.Close()
 
-	err = sendStats(ws)
-	if err != nil {
-		log.Println(err)
-	}
+	// Explicitely ignore this error. We don't want to spam standard output
+	// each time the other end of the websocket connection closes.
+	_ = sendStats(ws)
 }
 
 var upgrader = websocket.Upgrader{


### PR DESCRIPTION
There are 2 places in statsviz where errors can happen, in both we were logging them using `log`.
It's not ideal since not all users want that.
Furthermore these 2 logs were not particularly useful:
 - the first logged an error returned by `websocket.Upgrade`. However when that happens an HTTP error is already returned through the HTTP connection.
 - the second one is `sendStats()` that returned a possible write Error on the `websocket.Conn`. This happens each time the client (browser) is closed and so it's not really an error. 