### PR TITLE
Functional options api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
       uses: actions/checkout@v2
     - name: Vet
       run: go vet ./...
-    - name: Test
-      run: go test ./...
+    - name: Test and Coverage
+      run: go test -race -coverprofile=coverage.txt -covermode=atomic && bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/arl/statsviz)
 [![Go Report Card](https://goreportcard.com/badge/github.com/arl/statsviz)](https://goreportcard.com/report/github.com/arl/statsviz)
+[![codecov](https://codecov.io/gh/arl/statsviz/branch/master/graph/badge.svg)](https://codecov.io/gh/arl/statsviz)
 
 Statsviz
 ========

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ go func() {
 }()
 ```
 
-The handled path is `/debug/statsviz/`.
+By default the handled path is `/debug/statsviz/`.
 
 Then open your browser at http://localhost:6060/debug/statsviz/
 

--- a/_example/change_root.go
+++ b/_example/change_root.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"log"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/arl/statsviz"
+)
+
+func main() {
+	// Force the GC to work to make the plots "move".
+	go work()
+
+	// Create a serve mux and register statsviz handlers at /foo/bar
+	mux := http.NewServeMux()
+
+	if err := statsviz.Register(mux, statsviz.Root("/debug")); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}
+
+func work() {
+	// Generate some allocations
+	m := map[string][]byte{}
+
+	for {
+		b := make([]byte, 512+rand.Intn(16*1024))
+		m[strconv.Itoa(len(m)%(10*100))] = b
+
+		if len(m)%(10*100) == 0 {
+			m = make(map[string][]byte)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/_example/default.go
+++ b/_example/default.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -15,7 +16,7 @@ func main() {
 
 	// Register statsviz handlers on the default serve mux.
 	statsviz.RegisterDefault()
-	http.ListenAndServe(":8080", nil)
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
 func work() {

--- a/_example/mux.go
+++ b/_example/mux.go
@@ -16,7 +16,9 @@ func main() {
 
 	// Create a serve mux and register statsviz handlers.
 	mux := http.NewServeMux()
-	statsviz.Register(mux)
+	if err := statsviz.Register(mux); err != nil {
+		log.Fatal(err)
+	}
 
 	log.Fatal(http.ListenAndServe(":8080", mux))
 }

--- a/_example/mux.go
+++ b/_example/mux.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -17,7 +18,7 @@ func main() {
 	mux := http.NewServeMux()
 	statsviz.Register(mux)
 
-	http.ListenAndServe(":8080", mux)
+	log.Fatal(http.ListenAndServe(":8080", mux))
 }
 
 func work() {

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,18 @@
+// Package statsviz serves via its HTTP server an HTML page displaying live
+// visualization of the application runtime statistics.
+//
+// Either Register statsviz HTTP handlers with the http.ServeMux you're using
+// (preferred method):
+//  mux := http.NewServeMux()
+//  statsviz.Register(mux)
+//
+// Or register them with the http.DefaultServeMux:
+//  statsviz.RegisterDefault()
+//
+// If your application is not already running an HTTP server, you need to start
+// one. Add "net/http" and "log" to your imports and the following code to your
+// main function:
+//  go func() {
+//  	log.Println(http.ListenAndServe("localhost:6060", nil))
+//  }()
+package statsviz

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,38 @@
+package statsviz
+
+import (
+	"log"
+	"net/http"
+	"strings"
+)
+
+// Index responds to a request for /debug/statsviz with the statsviz HTML page
+// which shows a live visualization of the statistics sent by the application
+// over the websocket handler Ws.
+var Index = IndexAtRoot(defaultRoot)
+
+// IndexAtRoot returns an index statsviz handler rooted at root. It's useful if
+// you desire your server to responds with the statsviz HTML page at a
+// path that is different than /debug/statsviz.
+func IndexAtRoot(root string) http.Handler {
+	return http.StripPrefix(strings.TrimRight(root, "/")+"/", http.FileServer(assets))
+}
+
+// Ws upgrades the HTTP server connection to the WebSocket protocol and sends
+// application statistics every second.
+//
+// If the upgrade fails, an HTTP error response is sent to the client.
+func Ws(w http.ResponseWriter, r *http.Request) {
+	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
+
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("Ws: Upgrade error:", err)
+		return
+	}
+	defer ws.Close()
+
+	// Explicitly ignore this error. We don't want to spam standard output
+	// each time the other end of the websocket connection closes.
+	_ = sendStats(ws)
+}

--- a/handlers.go
+++ b/handlers.go
@@ -15,7 +15,8 @@ var Index = IndexAtRoot(defaultRoot)
 // you desire your server to responds with the statsviz HTML page at a
 // path that is different than /debug/statsviz.
 func IndexAtRoot(root string) http.Handler {
-	return http.StripPrefix(strings.TrimRight(root, "/")+"/", http.FileServer(assets))
+	prefix := strings.TrimRight(root, "/") + "/"
+	return http.StripPrefix(prefix, http.FileServer(assets))
 }
 
 // Ws upgrades the HTTP server connection to the WebSocket protocol and sends

--- a/handlers.go
+++ b/handlers.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"net/http"
 	"strings"
+
+	"github.com/arl/statsviz/websocket"
 )
 
 // Index responds to a request for /debug/statsviz with the statsviz HTML page
@@ -24,7 +26,10 @@ func IndexAtRoot(root string) http.Handler {
 //
 // If the upgrade fails, an HTTP error response is sent to the client.
 func Ws(w http.ResponseWriter, r *http.Request) {
-	upgrader.CheckOrigin = func(r *http.Request) bool { return true }
+	var upgrader = websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+	}
 
 	ws, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,45 @@
+package statsviz_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/arl/statsviz"
+)
+
+func testIndex(t *testing.T, f http.Handler, url string) {
+	t.Helper()
+
+	req := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	f.ServeHTTP(w, req)
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("http status %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if resp.Header.Get("Content-Type") != "text/html; charset=utf-8" {
+		t.Errorf("header[Content-Type] %s, want %s", resp.Header.Get("Content-Type"), "text/html; charset=utf-8")
+	}
+
+	if !strings.Contains(string(body), "goroutines") {
+		t.Errorf("body doesn't contain %q", "goroutines")
+	}
+}
+
+func TestIndex(t *testing.T) {
+	testIndex(t, statsviz.Index, "http://example.com/debug/statsviz/")
+}
+
+func TestIndexAtRoot(t *testing.T) {
+	testIndex(t, statsviz.IndexAtRoot("/debug/"), "http://example.com/debug/")
+	testIndex(t, statsviz.IndexAtRoot("/debug"), "http://example.com/debug/")
+	testIndex(t, statsviz.IndexAtRoot("/"), "http://example.com/")
+	testIndex(t, statsviz.IndexAtRoot("/test/"), "http://example.com/test/")
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -105,8 +105,30 @@ func testRegister(t *testing.T, f http.Handler, baseURL string) {
 func TestRegister(t *testing.T) {
 	t.Parallel()
 
-	mux := http.NewServeMux()
-	Register(mux)
+	t.Run("default", func(t *testing.T) {
+		mux := http.NewServeMux()
+		if err := Register(mux); err != nil {
+			t.Fatal(err)
+		}
 
-	testRegister(t, mux, "http://example.com/debug/statsviz/")
+		testRegister(t, mux, "http://example.com/debug/statsviz/")
+	})
+
+	t.Run("root", func(t *testing.T) {
+		mux := http.NewServeMux()
+		if err := Register(mux, Root("")); err != nil {
+			t.Fatal(err)
+		}
+
+		testRegister(t, mux, "http://example.com/")
+	})
+
+	t.Run("root2", func(t *testing.T) {
+		mux := http.NewServeMux()
+		if err := Register(mux, Root("/root/to/statsviz")); err != nil {
+			t.Fatal(err)
+		}
+
+		testRegister(t, mux, "http://example.com/root/to/statsviz/")
+	})
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -131,4 +131,16 @@ func TestRegister(t *testing.T) {
 
 		testRegister(t, mux, "http://example.com/root/to/statsviz/")
 	})
+
+	t.Run("root+frequency", func(t *testing.T) {
+		mux := http.NewServeMux()
+		err := Register(mux,
+			Root("/root/to/statsviz"),
+			SendFrequency(100*time.Millisecond))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testRegister(t, mux, "http://example.com/root/to/statsviz/")
+	})
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -36,10 +36,14 @@ func testIndex(t *testing.T, f http.Handler, url string) {
 }
 
 func TestIndex(t *testing.T) {
+	t.Parallel()
+
 	testIndex(t, Index, "http://example.com/debug/statsviz/")
 }
 
 func TestIndexAtRoot(t *testing.T) {
+	t.Parallel()
+
 	testIndex(t, IndexAtRoot("/debug/"), "http://example.com/debug/")
 	testIndex(t, IndexAtRoot("/debug"), "http://example.com/debug/")
 	testIndex(t, IndexAtRoot("/"), "http://example.com/")
@@ -87,6 +91,8 @@ func testWs(t *testing.T, f http.Handler, URL string) {
 }
 
 func TestWs(t *testing.T) {
+	t.Parallel()
+
 	testWs(t, http.HandlerFunc(Ws), "http://example.com/debug/statsviz/ws")
 }
 
@@ -97,6 +103,8 @@ func testRegister(t *testing.T, f http.Handler, baseURL string) {
 }
 
 func TestRegister(t *testing.T) {
+	t.Parallel()
+
 	mux := http.NewServeMux()
 	Register(mux)
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/arl/statsviz/websocket"
 )
@@ -103,9 +104,9 @@ func testRegister(t *testing.T, f http.Handler, baseURL string) {
 }
 
 func TestRegister(t *testing.T) {
-	t.Parallel()
-
 	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
 		mux := http.NewServeMux()
 		if err := Register(mux); err != nil {
 			t.Fatal(err)
@@ -115,6 +116,8 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("root", func(t *testing.T) {
+		t.Parallel()
+
 		mux := http.NewServeMux()
 		if err := Register(mux, Root("")); err != nil {
 			t.Fatal(err)
@@ -124,6 +127,8 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("root2", func(t *testing.T) {
+		t.Parallel()
+
 		mux := http.NewServeMux()
 		if err := Register(mux, Root("/root/to/statsviz")); err != nil {
 			t.Fatal(err)
@@ -133,6 +138,8 @@ func TestRegister(t *testing.T) {
 	})
 
 	t.Run("root+frequency", func(t *testing.T) {
+		t.Parallel()
+
 		mux := http.NewServeMux()
 		err := Register(mux,
 			Root("/root/to/statsviz"),

--- a/register.go
+++ b/register.go
@@ -1,0 +1,68 @@
+package statsviz
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// RegisterDefault registers statsviz HTTP handlers on the default serve mux.
+//
+// Note this is not advised on a production server, unless it only serves on
+// localhost.
+func RegisterDefault(opts ...OptionFunc) {
+	if err := Register(http.DefaultServeMux, opts...); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Root sets the root of statsviz handlers.
+func Root(root string) OptionFunc {
+	return func(s *server) error {
+		s.root = root
+		return nil
+	}
+}
+
+// SendFrequency defines the frequency at which statistics are sent from the
+// application to the HTML page.
+func SendFrequency(freq time.Duration) OptionFunc {
+	return func(s *server) error {
+		s.freq = freq
+		return nil
+	}
+}
+
+// An OptionFunc is a server configuration option.
+type OptionFunc func(s *server) error
+
+const defaultRoot = "/debug/statsviz"
+
+// Register registers statsviz HTTP handlers on the provided mux.
+func Register(mux *http.ServeMux, opts ...OptionFunc) error {
+	s := &server{
+		mux:  mux,
+		root: defaultRoot,
+		freq: defaultSendFrequency,
+	}
+
+	for _, opt := range opts {
+		if err := opt(s); err != nil {
+			return err
+		}
+	}
+
+	s.register()
+	return nil
+}
+
+type server struct {
+	mux  *http.ServeMux
+	freq time.Duration
+	root string
+}
+
+func (s *server) register() {
+	s.mux.Handle(s.root+"/", IndexAtRoot(s.root))
+	s.mux.HandleFunc(s.root+"/ws", Ws)
+}

--- a/statsviz.go
+++ b/statsviz.go
@@ -1,25 +1,3 @@
-// Package statsviz serves via its HTTP server an HTML page displaying live
-// visualization of the application runtime statistics.
-//
-// The package is typically only imported for the side effect of
-// registering its HTTP handler.
-// The handled path is /debug/statsviz/.
-//
-// To use statsviz, link this package into your program:
-//	import _ "github.com/arl/statsviz"
-//
-// If your application is not already running an http server, you
-// need to start one. Add "net/http" and "log" to your imports and
-// the following code to your main function:
-//
-// 	go func() {
-// 		log.Println(http.ListenAndServe("localhost:6060", nil))
-// 	}()
-//
-// If you are not using DefaultServeMux, you will have to register handlers
-// with the mux you are using.
-//
-// Then open your browser at http://localhost:6060/debug/statsviz/
 package statsviz
 
 import (

--- a/statsviz.go
+++ b/statsviz.go
@@ -7,11 +7,6 @@ import (
 	"github.com/arl/statsviz/websocket"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-}
-
 type stats struct {
 	Mem          runtime.MemStats
 	NumGoroutine int

--- a/statsviz.go
+++ b/statsviz.go
@@ -32,8 +32,8 @@ import (
 
 // Register registers statsviz HTTP handlers on the provided mux.
 func Register(mux *http.ServeMux) {
-	mux.Handle("/debug/statsviz/", Index)
-	mux.HandleFunc("/debug/statsviz/ws", Ws)
+	s := server{mux: mux}
+	s.register()
 }
 
 // RegisterDefault registers statsviz HTTP handlers on the default serve mux.
@@ -41,7 +41,8 @@ func Register(mux *http.ServeMux) {
 // Note this is not advised on a production server, unless it only serves on
 // localhost.
 func RegisterDefault() {
-	Register(http.DefaultServeMux)
+	s := server{mux: http.DefaultServeMux}
+	s.register()
 }
 
 // Index responds to a request for /debug/statsviz with the statsviz HTML page
@@ -68,6 +69,15 @@ func Ws(w http.ResponseWriter, r *http.Request) {
 	// Explicitly ignore this error. We don't want to spam standard output
 	// each time the other end of the websocket connection closes.
 	_ = sendStats(ws)
+}
+
+type server struct {
+	mux *http.ServeMux
+}
+
+func (s *server) register() {
+	s.mux.Handle("/debug/statsviz/", Index)
+	s.mux.HandleFunc("/debug/statsviz/ws", Ws)
 }
 
 var upgrader = websocket.Upgrader{


### PR DESCRIPTION
Improve public API, which remains 100% compatible, by adding functional options to Register.
At the moment, options are:

 - `Root(root string)` -> allow to change handler root (for example to have statsviz at `http://host:port/my/special/statsviz/path` rather than `/debug/statsviz`

 - `SendFrequency(freq time.Duration)` -> allow to specify a different frequency for sending the runtime stats from the application to the user interface (default is 1s). Note that at the moment the user interface keeps track of 60 points, whatever is the frequency. 


Improve code organization.
Add handler tests
Fix a data race (appearing in parallel tests). On non-test code, you would have had to register handlers twice to see that. Anyway it's fixed