### PR TITLE
ci: build all examples

### DIFF
--- a/.github/scripts/build_examples.sh
+++ b/.github/scripts/build_examples.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+for gofile in $(find _example -name '*.go') ; do \
+  go build $gofile
+done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       # Regenerating assets should only change the modtime
       # of embedded files and nothing else
       run: ${GITHUB_WORKSPACE}/.github/scripts/check_assets.sh
-      shell: bash
+      shell: sh
       if: github.base_ref == 'master'
   test:
     strategy:
@@ -33,3 +33,6 @@ jobs:
       run: go vet ./...
     - name: Test and Coverage
       run: go test -race -coverprofile=coverage.txt -covermode=atomic && bash <(curl -s https://codecov.io/bash)
+    - name: Build examples
+      run: ${GITHUB_WORKSPACE}/.github/scripts/build_examples.sh
+      shell: sh


### PR DESCRIPTION
Add a CI step to ensure that all examples (under `_example`) can be built without compilation errors.
A future improvement would be to ensure that all examples not only compile but also work (by calling the served handlers).
But for now this is better than nothing