### PR TITLE
ci: add codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,24 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "80...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - "_example"
+  - "assets_*.go"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,15 @@ jobs:
     - name: Vet
       run: go vet ./...
     - name: Test and Coverage
-      run: go test -race -coverprofile=coverage.txt -covermode=atomic && bash <(curl -s https://codecov.io/bash)
+      run: go test -race ./...
     - name: Build examples
       run: ${GITHUB_WORKSPACE}/.github/scripts/build_examples.sh
       shell: sh
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.15.x
+    - run: go test -race -coverprofile=coverage.txt -covermode=atomic && bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Configure codecov by adding `codecov.yml` in order to ignore generate assets and example files in order to have more accurate and representative coverage reports