### PR TITLE
Support custom frequency

### DIFF
--- a/_example/options/main.go
+++ b/_example/options/main.go
@@ -13,10 +13,14 @@ func main() {
 	// Force the GC to work to make the plots "move".
 	go example.Work()
 
-	// Create a serve mux and register statsviz handlers at /foo/bar with send frequency 250ms
+	// Create a serve mux and register statsviz handlers at /foo/bar with a send
+	// frequency of 250ms
 	mux := http.NewServeMux()
 
-	err := statsviz.Register(mux, statsviz.Root("/foo/bar"), statsviz.SendFrequency(250*time.Millisecond))
+	err := statsviz.Register(mux,
+		statsviz.Root("/foo/bar"),
+		statsviz.SendFrequency(250*time.Millisecond),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/_example/options/main.go
+++ b/_example/options/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/arl/statsviz"
 	example "github.com/arl/statsviz/_example"
@@ -12,10 +13,11 @@ func main() {
 	// Force the GC to work to make the plots "move".
 	go example.Work()
 
-	// Create a serve mux and register statsviz handlers at /foo/bar
+	// Create a serve mux and register statsviz handlers at /foo/bar with send frequency 250ms
 	mux := http.NewServeMux()
 
-	if err := statsviz.Register(mux, statsviz.Root("/foo/bar")); err != nil {
+	err := statsviz.Register(mux, statsviz.Root("/foo/bar"), statsviz.SendFrequency(250*time.Millisecond))
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -3,6 +3,7 @@ package statsviz
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/arl/statsviz/websocket"
 )
@@ -20,23 +21,28 @@ func IndexAtRoot(root string) http.Handler {
 	return http.StripPrefix(prefix, http.FileServer(assets))
 }
 
-// Ws upgrades the HTTP server connection to the WebSocket protocol and sends
-// application statistics every second.
+// Ws is a default handler created with 'NewWsHandler' that sends application statistics every second
+var Ws = NewWsHandler(defaultSendFrequency)
+
+// NewWsHandler returns a handler that upgrades the HTTP server connection to the WebSocket
+// protocol and sends application statistics every 'frequency'.
 //
 // If the upgrade fails, an HTTP error response is sent to the client.
-func Ws(w http.ResponseWriter, r *http.Request) {
-	var upgrader = websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
-	}
+func NewWsHandler(frequency time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var upgrader = websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+		}
 
-	ws, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		return
-	}
-	defer ws.Close()
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
 
-	// Explicitly ignore this error. We don't want to spam standard output
-	// each time the other end of the websocket connection closes.
-	_ = sendStats(ws)
+		// Explicitly ignore this error. We don't want to spam standard output
+		// each time the other end of the websocket connection closes.
+		_ = sendStats(ws, frequency)
+	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -21,11 +21,12 @@ func IndexAtRoot(root string) http.Handler {
 	return http.StripPrefix(prefix, http.FileServer(assets))
 }
 
-// Ws is a default handler created with 'NewWsHandler' that sends application statistics every second
+// Ws is a default Websocket handler, created with NewWsHandler, sending statistics 
+// at the default frequency of 1 message per second.
 var Ws = NewWsHandler(defaultSendFrequency)
 
 // NewWsHandler returns a handler that upgrades the HTTP server connection to the WebSocket
-// protocol and sends application statistics every 'frequency'.
+// protocol and sends application statistics at the given frequency.
 //
 // If the upgrade fails, an HTTP error response is sent to the client.
 func NewWsHandler(frequency time.Duration) http.HandlerFunc {

--- a/register.go
+++ b/register.go
@@ -37,7 +37,10 @@ func SendFrequency(freq time.Duration) OptionFunc {
 // An OptionFunc is a server configuration option.
 type OptionFunc func(s *server) error
 
-const defaultRoot = "/debug/statsviz"
+const (
+	defaultRoot          = "/debug/statsviz"
+	defaultSendFrequency = time.Second
+)
 
 // Register registers statsviz HTTP handlers on the provided mux.
 func Register(mux *http.ServeMux, opts ...OptionFunc) error {
@@ -65,5 +68,5 @@ type server struct {
 
 func (s *server) register() {
 	s.mux.Handle(s.root+"/", IndexAtRoot(s.root))
-	s.mux.HandleFunc(s.root+"/ws", Ws)
+	s.mux.HandleFunc(s.root+"/ws", NewWsHandler(s.freq))
 }

--- a/statsviz.go
+++ b/statsviz.go
@@ -12,11 +12,9 @@ type stats struct {
 	NumGoroutine int
 }
 
-const defaultSendFrequency = time.Second
-
 // sendStats indefinitely send runtime statistics on the websocket connection.
-func sendStats(conn *websocket.Conn) error {
-	tick := time.NewTicker(defaultSendFrequency)
+func sendStats(conn *websocket.Conn, frequency time.Duration) error {
+	tick := time.NewTicker(frequency)
 	defer tick.Stop()
 
 	var stats stats


### PR DESCRIPTION
I noticed that `server.freq` is unused despite the fact there's a special option to set custom frequency. So, I added a function `NewWsHandler` that accepts send frequency and returns `http.HandlerFunc`. Old behavior of `Ws` is preserved.