### PR TITLE
Examples/reorganize

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-      - run: go test -race -coverprofile=coverage.txt -covermode=atomic && bash <(curl -s https://codecov.io/bash)
+      - run: go test -coverprofile=coverage.txt && bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Instant live visualization of your Go application runtime statistics
  - Enjoy... 
 
 
-How does it work?
+How does that work?
 -----------------
 
 Statsviz serves 2 HTTP handlers.
@@ -39,7 +39,7 @@ to [Register](https://pkg.go.dev/github.com/arl/statsviz@v0.2.1#Register).
 Usage
 -----
 
-    go get -u github.com/arl/statsviz
+    go get github.com/arl/statsviz
 
 Either `Register` statsviz HTTP handlers with the [http.ServeMux](https://pkg.go.dev/net/http?tab=doc#ServeMux) you're using (preferred method):
 
@@ -91,32 +91,20 @@ On the plots where it matters, garbage collections are shown as vertical lines.
 ### GC/CPU fraction
 <img alt="GC/CPU fraction plot image" src="https://github.com/arl/statsviz/raw/readme-docs/gc-cpu-fraction.png" width="600">
 
+
 Examples
 --------
 
-Using `http.DefaultServeMux`:
- - [_example/default/main.go](./_example/default/main.go)
-
-Using your own `http.ServeMux`:
- - [_example/mux/main.go](./_example/mux/main.go)
-
-Serve `statsviz` on `/foo/bar` instead of default `/debug/statsviz`:
- - [_example/root/main.go](./_example/root/main.go)
-
-Serve on `https` (and `wss` for websocket):
- - [_example/https/main.go](./_example/https/main.go)
-
-With [gorilla/mux](https://github.com/gorilla/mux) router:
- - [_example/gorilla/main.go](./_example/gorilla/main.go)
-
-Using [labstack/echo](https://github.com/labstack/echo) router:
- - [_example/echo/main.go](./_example/echo.go)
-
-With [gin-gonic/gin](https://github.com/gin-gonic/gin) web framework:
- - [_example/gin/main.go](./_example/gin/main.go)
-
-With [go-chi/chi](https://github.com/go-chi/chi) router:
- - [_example/chi/main.go](./_example/chi/main.go)
+Have a look at the [_example](./_example/README.md) directory to see some
+different ways to register Statsviz HTTP handlers, such as:
+ - using `http.DefaultServeMux`
+ - using your own `http.ServeMux`
+ - register at `/foo/bar` instead of `/debug/statviz`
+ - use `https://` rather than `http://`
+ - using with various Go HTTP libraries/frameworks:
+   - [fasthttp](https://github.com/valyala/fasthttp)
+   - [gin](https://github.com/gin-gonic/gin)
+   - and many others thanks to wonderful contributors!
 
 
 Contributing
@@ -136,10 +124,12 @@ Roadmap
  - [ ] save timeseries to disk
  - [ ] load from disk previously saved timeseries
 
+
 Changelog
 ---------
 
 See [CHANGELOG.md](./CHANGELOG.md).
+
 
 License
 -------

--- a/_example/README.md
+++ b/_example/README.md
@@ -16,6 +16,9 @@ Serve on `https` (and `wss` for websocket):
 With [gorilla/mux](https://github.com/gorilla/mux) router:
  - [_example/gorilla/main.go](./_example/gorilla/main.go)
 
+Using [valyala/fasthttp](https://github.com/valyala/fasthttp) and [soheilhy/cmux](https://github.com/soheilhy/cmux):
+ - [_example/fasthttp/main.go](./_example/fasthttp/main.go)
+
 Using [labstack/echo](https://github.com/labstack/echo) router:
  - [_example/echo/main.go](./_example/echo.go)
 
@@ -24,4 +27,7 @@ With [gin-gonic/gin](https://github.com/gin-gonic/gin) web framework:
 
 With [go-chi/chi](https://github.com/go-chi/chi) router:
  - [_example/chi/main.go](./_example/chi/main.go)
+
+With [gofiber/fiber](https://github.com/gofiber/fiber) web framework:
+ - [_example/fiber/main.go](./_example/fiber/main.go)
 

--- a/_example/README.md
+++ b/_example/README.md
@@ -1,6 +1,27 @@
 Examples
 ========
 
-This shows how to register statsviz HTTP handlers in various contexts.
+Using `http.DefaultServeMux`:
+ - [_example/default/main.go](./_example/default/main.go)
 
-There's one example per directory.
+Using your own `http.ServeMux`:
+ - [_example/mux/main.go](./_example/mux/main.go)
+
+Serve `statsviz` on `/foo/bar` instead of default `/debug/statsviz`:
+ - [_example/root/main.go](./_example/root/main.go)
+
+Serve on `https` (and `wss` for websocket):
+ - [_example/https/main.go](./_example/https/main.go)
+
+With [gorilla/mux](https://github.com/gorilla/mux) router:
+ - [_example/gorilla/main.go](./_example/gorilla/main.go)
+
+Using [labstack/echo](https://github.com/labstack/echo) router:
+ - [_example/echo/main.go](./_example/echo.go)
+
+With [gin-gonic/gin](https://github.com/gin-gonic/gin) web framework:
+ - [_example/gin/main.go](./_example/gin/main.go)
+
+With [go-chi/chi](https://github.com/go-chi/chi) router:
+ - [_example/chi/main.go](./_example/chi/main.go)
+

--- a/_example/fasthttp/install.sh
+++ b/_example/fasthttp/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+go get github.com/fasthttp/router
+go get github.com/soheilhy/cmux
+go get github.com/valyala/fasthttp@v1.23.0
+go get github.com/valyala/fasthttp/fasthttpadaptor@v1.23.0

--- a/_example/fasthttp/main.go
+++ b/_example/fasthttp/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/fasthttp/router"
+	"github.com/soheilhy/cmux"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttpadaptor"
+
+	"github.com/arl/statsviz"
+	example "github.com/arl/statsviz/_example"
+)
+
+func main() {
+	// Force the GC to work to make the plots "move".
+	go example.Work()
+
+	// Create the main listener and mux
+	l, _ := net.Listen("tcp", ":8080")
+	m := cmux.New(l)
+	ws := http.NewServeMux()
+
+	// fasthttp routers
+	r := router.New()
+	r.GET("/", func(ctx *fasthttp.RequestCtx) {
+		fmt.Fprintf(ctx, "Hello, world!")
+	})
+
+	// statsviz
+	r.GET("/debug/statsviz/{filepath:*}", fasthttpadaptor.NewFastHTTPHandler(statsviz.Index))
+	ws.HandleFunc("/debug/statsviz/ws", statsviz.Ws)
+
+	// Server start
+	go http.Serve(m.Match(cmux.HTTP1HeaderField("Upgrade", "websocket")), ws)
+	go fasthttp.Serve(m.Match(cmux.Any()), r.Handler)
+	m.Serve()
+}

--- a/_example/fiber/install.sh
+++ b/_example/fiber/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+go get github.com/gofiber/fiber/v2
+go get github.com/gofiber/adaptor/v2

--- a/_example/fiber/main.go
+++ b/_example/fiber/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/gofiber/adaptor/v2"
+	"github.com/gofiber/fiber/v2"
+	"github.com/soheilhy/cmux"
+
+	"github.com/arl/statsviz"
+	example "github.com/arl/statsviz/_example"
+)
+
+func main() {
+	// Force the GC to work to make the plots "move".
+	go example.Work()
+
+	// Create the main listener and mux
+	l, _ := net.Listen("tcp", ":8080")
+	m := cmux.New(l)
+	ws := http.NewServeMux()
+
+	// Fiber instance
+	app := fiber.New()
+	app.Get("/", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World 👋!")
+	})
+
+	// statsviz
+	app.Get("/debug/statsviz", adaptor.HTTPHandler(statsviz.Index))
+	ws.HandleFunc("/debug/statsviz/ws", statsviz.Ws)
+
+	// Server start
+	go http.Serve(m.Match(cmux.HTTP1HeaderField("Upgrade", "websocket")), ws)
+	go app.Listener(m.Match(cmux.Any()))
+	m.Serve()
+}


### PR DESCRIPTION
Reorganize examples: add a link to the _example README from the main README, and move the list of examples there