### PR TITLE
.gitattributes: make gh-linguist not detect js code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-static/** linguist-detectable=false
+internal/static/** linguist-detectable=false


### PR DESCRIPTION
Project appears as a javascript project in github without this