### PR TITLE
Fix/content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.5.2 / 2023-03-29
+==============
+  * Ensure all files have a correct Content-Type (#106)
+
 v0.5.1 / 2022-09-30
 ==============
   * Fix UI on Firefox (#83)

--- a/handlers.go
+++ b/handlers.go
@@ -46,8 +46,21 @@ func hijack(h http.Handler) http.HandlerFunc {
 			buf.WriteTo(w)
 			return
 		}
+		// Force Content-Type if needed.
+		if ct, ok := contentTypes[r.URL.Path]; ok {
+			w.Header().Add("Content-Type", ct)
+		}
+
 		h.ServeHTTP(w, r)
 	}
+}
+
+// Force Content-Type HTTP header for certain files of some javascript libraries
+// that have no extensions. Otherwise the http fileserver would serve them under
+// "Content-Type = text/plain".
+var contentTypes = map[string]string{
+	"libs/js/popperjs-core2": "text/javascript",
+	"libs/js/tippy.js@6":     "text/javascript",
 }
 
 // Ws is a default Websocket handler, created with NewWsHandler, sending statistics


### PR DESCRIPTION
Thanks to @rogozhka for his findings in #105
Because some files of certain javascript libraries have no extension they were served with `Content-Type text/plain` which apparently can cause issues when *strict mime type checking* is enabled in the browser.

This fixes #97 and probably #95