### PR TITLE
Add dark/light mode

### DIFF
--- a/internal/static/css/statsviz.css
+++ b/internal/static/css/statsviz.css
@@ -4,6 +4,19 @@ body {
     margin: 0;
 }
 
+nav.navbar {
+    background-color: #f8f9fa;
+}
+
+body.dark-theme {
+    color: white;
+    background-color: #282a2c;
+}
+
+body.dark-theme nav.navbar span.action svg {
+    color: lightgray;
+}
+
 #header {
     text-align: center;
 }

--- a/internal/static/index.html
+++ b/internal/static/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-    <nav class="navbar navbar-expand-lg navbar-light bg-light" style="background-color: #84afce;">
+    <nav id="navbar" class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container-xxl">
             <a class="navbar-brand" href="#">Statsviz</a>
             <button class="navbar-toggler" type="button">
@@ -45,8 +45,11 @@
                 <option value="300">5 minute</option>
                 <option value="600">10 minutes</option>
               </select>
-            <span title="play/pause">
+            <span class="action" title="play/pause">
                 <input id="play_pause" type="checkbox" data-toggle="toggle" data-onstyle="default" data-on="<i class='fa fa-play'></i>" data-off="<i class='fa fa-pause'></i>" data-size="mini" data-bs-toggle="tooltip">
+            </span>
+            <span class="action" title="color theme">
+                <input id="color_theme_sw" type="checkbox" data-toggle="toggle" data-onstyle="default" data-on="<i class='fa fa-circle-half-stroke'></i>" data-off="<i class='fa fa-circle-half-stroke'></i>" data-size="mini" data-bs-toggle="tooltip">
             </span>
         </div>
     </nav>

--- a/internal/static/js/app.js
+++ b/internal/static/js/app.js
@@ -1,5 +1,6 @@
 import * as stats from './stats.js';
 import * as plot from "./plot.js";
+import * as theme from "./theme.js";
 import PlotsDef from './plotsdef.js';
 
 const buildWebsocketURI = () => {
@@ -90,7 +91,6 @@ const configurePlots = (plotdefs) => {
 }
 
 const attachPlots = () => {
-    let row = null;
     let plotsDiv = $('#plots');
     plotsDiv.empty();
 
@@ -124,3 +124,22 @@ const updatePlots = () => {
         }
     });
 }
+
+const updatePlotsLayout = () => {
+    plots.forEach(plot => {
+        plot.updateTheme();
+    });
+}
+
+theme.updateThemeMode();
+
+/**
+ * Change color theme when the user presses the theme switch button
+ */
+$('#color_theme_sw').change(() => {
+    const themeMode = theme.getThemeMode();
+    const newTheme = themeMode === "dark" && "light" || "dark";
+    localStorage.setItem("theme-mode", newTheme);    
+    theme.updateThemeMode();
+    updatePlotsLayout();
+});

--- a/internal/static/js/theme.js
+++ b/internal/static/js/theme.js
@@ -1,0 +1,36 @@
+/**
+ * Get color theme based on previous user choice or browser theme
+ */
+export const getThemeMode = () => {
+  let themeMode = localStorage.getItem("theme-mode");
+
+  if (themeMode === null) {
+    const isDark =
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+    themeMode = (isDark && "dark") || "light";
+
+    localStorage.setItem("theme-mode", themeMode);
+  }
+
+  return themeMode;
+};
+
+/**
+ * Set light or dark theme
+ */
+export const updateThemeMode = () => {
+  if (getThemeMode() === "dark") {
+    document.body.classList.add("dark-theme");
+    document
+      .getElementById("navbar")
+      .classList.replace("navbar-light", "navbar-dark");
+    document.getElementById("navbar").classList.replace("bg-light", "bg-dark");
+  } else {
+    document.body.classList.remove("dark-theme");
+    document
+      .getElementById("navbar")
+      .classList.replace("navbar-dark", "navbar-light");
+    document.getElementById("navbar").classList.replace("bg-dark", "bg-light");
+  }
+};


### PR DESCRIPTION
Add support for dark/light theme

The browser theme is initially used. A switch in the navbar let the user choose their theme. The selection is saved into localStorage for persistency.

Theme colors seems good but can be changed if not of your liking

![image](https://user-images.githubusercontent.com/122749/235122927-ca5a87e1-91e3-4e83-b894-a5ecdff256ff.png)


Fixes https://github.com/arl/statsviz/issues/23