### PR TITLE
Server zero value dont panic on register

### DIFF
--- a/_example/chi/go.mod
+++ b/_example/chi/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.24.5
 
 require (
-	github.com/arl/statsviz v0.7.0
+	github.com/arl/statsviz v0.7.1
 	github.com/go-chi/chi/v5 v5.2.2
 )
 

--- a/_example/chi/go.sum
+++ b/_example/chi/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
 github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/_example/default/go.mod
+++ b/_example/default/go.mod
@@ -4,6 +4,6 @@ go 1.23
 
 toolchain go1.24.5
 
-require github.com/arl/statsviz v0.7.0
+require github.com/arl/statsviz v0.7.1
 
 require github.com/gorilla/websocket v1.5.3 // indirect

--- a/_example/default/go.sum
+++ b/_example/default/go.sum
@@ -1,3 +1,5 @@
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/_example/echo/go.mod
+++ b/_example/echo/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.5
 
 require (
-	github.com/arl/statsviz v0.7.0
+	github.com/arl/statsviz v0.7.1
 	github.com/labstack/echo/v4 v4.13.4
 )
 

--- a/_example/echo/go.sum
+++ b/_example/echo/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/_example/fasthttp/go.mod
+++ b/_example/fasthttp/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.5
 
 require (
-	github.com/arl/statsviz v0.7.0
+	github.com/arl/statsviz v0.7.1
 	github.com/fasthttp/router v1.5.4
 	github.com/soheilhy/cmux v0.1.5
 	github.com/valyala/fasthttp v1.64.0

--- a/_example/fasthttp/go.sum
+++ b/_example/fasthttp/go.sum
@@ -2,6 +2,8 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/fasthttp/router v1.5.4 h1:oxdThbBwQgsDIYZ3wR1IavsNl6ZS9WdjKukeMikOnC8=
 github.com/fasthttp/router v1.5.4/go.mod h1:3/hysWq6cky7dTfzaaEPZGdptwjwx0qzTgFCKEWRjgc=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/_example/fiber/go.mod
+++ b/_example/fiber/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.24.5
 
 require (
-	github.com/arl/statsviz v0.7.0
+	github.com/arl/statsviz v0.7.1
 	github.com/gofiber/adaptor/v2 v2.2.1
 	github.com/gofiber/fiber/v2 v2.52.9
 	github.com/soheilhy/cmux v0.1.5

--- a/_example/fiber/go.sum
+++ b/_example/fiber/go.sum
@@ -2,6 +2,8 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/gofiber/adaptor/v2 v2.2.1 h1:givE7iViQWlsTR4Jh7tB4iXzrlKBgiraB/yTdHs9Lv4=
 github.com/gofiber/adaptor/v2 v2.2.1/go.mod h1:AhR16dEqs25W2FY/l8gSj1b51Azg5dtPDmm+pruNOrc=
 github.com/gofiber/fiber/v2 v2.52.9 h1:YjKl5DOiyP3j0mO61u3NTmK7or8GzzWzCFzkboyP5cw=

--- a/_example/gin/go.mod
+++ b/_example/gin/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.24.5
 
 require (
-	github.com/arl/statsviz v0.7.0
+	github.com/arl/statsviz v0.7.1
 	github.com/gin-gonic/gin v1.10.1
 )
 

--- a/_example/gin/go.sum
+++ b/_example/gin/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=

--- a/_example/gorilla/go.mod
+++ b/_example/gorilla/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.24.5
 
 require (
-	github.com/arl/statsviz v0.7.0
+	github.com/arl/statsviz v0.7.1
 	github.com/gorilla/mux v1.8.1
 )
 

--- a/_example/gorilla/go.sum
+++ b/_example/gorilla/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/_example/https/go.mod
+++ b/_example/https/go.mod
@@ -4,6 +4,6 @@ go 1.23
 
 toolchain go1.24.5
 
-require github.com/arl/statsviz v0.7.0
+require github.com/arl/statsviz v0.7.1
 
 require github.com/gorilla/websocket v1.5.3 // indirect

--- a/_example/https/go.sum
+++ b/_example/https/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/_example/iris/go.mod
+++ b/_example/iris/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.5
 
 require (
-	github.com/arl/statsviz v0.7.0
+	github.com/arl/statsviz v0.7.1
 	github.com/kataras/iris/v12 v12.2.11
 )
 

--- a/_example/iris/go.sum
+++ b/_example/iris/go.sum
@@ -16,6 +16,8 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/_example/middleware/go.mod
+++ b/_example/middleware/go.mod
@@ -4,6 +4,6 @@ go 1.23
 
 toolchain go1.24.5
 
-require github.com/arl/statsviz v0.7.0
+require github.com/arl/statsviz v0.7.1
 
 require github.com/gorilla/websocket v1.5.3 // indirect

--- a/_example/middleware/go.sum
+++ b/_example/middleware/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/_example/mux/go.mod
+++ b/_example/mux/go.mod
@@ -4,6 +4,6 @@ go 1.23
 
 toolchain go1.24.5
 
-require github.com/arl/statsviz v0.7.0
+require github.com/arl/statsviz v0.7.1
 
 require github.com/gorilla/websocket v1.5.3 // indirect

--- a/_example/mux/go.sum
+++ b/_example/mux/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/_example/options/go.mod
+++ b/_example/options/go.mod
@@ -4,6 +4,6 @@ go 1.23
 
 toolchain go1.24.5
 
-require github.com/arl/statsviz v0.7.0
+require github.com/arl/statsviz v0.7.1
 
 require github.com/gorilla/websocket v1.5.3 // indirect

--- a/_example/options/go.sum
+++ b/_example/options/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/_example/userplots/go.mod
+++ b/_example/userplots/go.mod
@@ -4,6 +4,6 @@ go 1.23
 
 toolchain go1.24.5
 
-require github.com/arl/statsviz v0.7.0
+require github.com/arl/statsviz v0.7.1
 
 require github.com/gorilla/websocket v1.5.3 // indirect

--- a/_example/userplots/go.sum
+++ b/_example/userplots/go.sum
@@ -1,5 +1,7 @@
 github.com/arl/statsviz v0.7.0 h1:ozKk1Jnl6crKqdmLHHT/FRi3gUkcq7x2YIs+O+uLnDk=
 github.com/arl/statsviz v0.7.0/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
+github.com/arl/statsviz v0.7.1 h1:W32VBGV/YBTMg3sBsr1Ix1bJzrykZHWNZS7quqtDqYc=
+github.com/arl/statsviz v0.7.1/go.mod h1:uFJZYUcGDeFpo/Mb9nLkq/83YUYaib2IccejOm+y1t0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/_example/zerovalue/go.mod
+++ b/_example/zerovalue/go.mod
@@ -1,0 +1,11 @@
+module example/default
+
+go 1.23.0
+
+toolchain go1.24.5
+
+require github.com/arl/statsviz v0.7.1
+
+require github.com/gorilla/websocket v1.5.3 // indirect
+
+replace github.com/arl/statsviz => ../../

--- a/_example/zerovalue/go.sum
+++ b/_example/zerovalue/go.sum
@@ -1,0 +1,8 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=
+golang.org/x/tools v0.36.0/go.mod h1:WBDiHKJK8YgLHlcQPYQzNCkUxUypCaa5ZegCVutKm+s=

--- a/_example/zerovalue/main.go
+++ b/_example/zerovalue/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/arl/statsviz"
+	example "github.com/arl/statsviz/_example"
+)
+
+func main() {
+	// Force the GC to work to make the plots "move".
+	go example.Work()
+
+	// Register with the Server zero value.
+	var ss statsviz.Server
+	ss.Register(http.DefaultServeMux)
+
+	fmt.Println("Point your browser to http://localhost:8079/debug/statsviz/")
+	log.Fatal(http.ListenAndServe(":8079", nil))
+}

--- a/statsviz_test.go
+++ b/statsviz_test.go
@@ -164,6 +164,16 @@ func TestRegister(t *testing.T) {
 		testRegister(t, mux, "http://example.com/debug/statsviz/")
 	})
 
+	t.Run("zero-value", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+
+		var srv Server
+		srv.Register(mux)
+		testRegister(t, mux, "http://example.com/debug/statsviz/")
+	})
+
 	t.Run("root", func(t *testing.T) {
 		t.Parallel()
 

--- a/zerovalue.txt
+++ b/zerovalue.txt
@@ -1,0 +1,10 @@
+cp $STATSVIZ_ROOT/_example/default/main.go .
+cp $STATSVIZ_ROOT/_example/default/go.mod .
+
+go mod edit -replace=github.com/arl/statsviz=$STATSVIZ_ROOT
+go mod edit -replace=github.com/arl/statsviz/_example=$STATSVIZ_ROOT/_example
+go mod tidy
+
+go build main.go
+! exec ./main &
+checkui http://localhost:8079/debug/statsviz/


### PR DESCRIPTION
Before this change, you could call Register on Server zero-value. This
would not fail, but the HTTP handler would panic later.
We now ensure that Server can be used as-is.

Add an _example (which also gets tested for panic) to catch future regressions on this.